### PR TITLE
Asa 5378-Allow users to use a comment in queue_analysis command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you don't have an account, register on [HCL AppScan on Cloud (ASoC)](https://
 | analysis_timout_minutes | If **wait_for_analysis** is true, the number of minutes to wait for analysis to complete. | 30 minutes |
 | fail_for_noncompliance | If **wait_for_analysis** is true, fail the job if any non-compliant issues are found in the scan. | false |
 | failure_threshold | If **fail_for_noncompliance** is enabled, the severity that indicates a failure. Lesser severities will not be considered a failure. For example, if **failure_threshold** is set to Medium, Informational and/or Low severity issues will not cause a failure. Medium, High, and/or Critical issues will cause a failure. | Low |
+| comment | A comment to associate the scan with.
 
 # Examples
 ```yaml

--- a/src/client.js
+++ b/src/client.js
@@ -63,10 +63,10 @@ function runAnalysis() {
             args += ' -ps';
         }
 		
-		let commentOption = utils.sanitizeString(process.env.INPUT_COMMENT);
-		if (commentOption) {
-			args += ' -c \"' + commentOption + '\"';
-		}
+        let commentOption = utils.sanitizeString(process.env.INPUT_COMMENT);
+        if (commentOption) {
+            args += ' -c \"' + commentOption + '\"';
+        }
 
         let appId = utils.sanitizeString(process.env.INPUT_APPLICATION_ID);
         if(!appId) {

--- a/src/client.js
+++ b/src/client.js
@@ -36,6 +36,7 @@ function generateIrx() {
     if(isArgumentEnabled(process.env.INPUT_OPEN_SOURCE_ONLY)) {
         args += '-oso ';
     }
+	
     if(isArgumentEnabled(process.env.INPUT_SCAN_BUILD_OUTPUTS)) {
         args = args.replace('-sco ', '');
     }
@@ -61,13 +62,18 @@ function runAnalysis() {
         if(isArgumentEnabled(process.env.INPUT_PERSONAL_SCAN)) {
             args += ' -ps';
         }
+		
+		let commentOption = utils.sanitizeString(process.env.INPUT_COMMENT);
+		if (commentOption) {
+			args += ' -c \"' + commentOption + '\"';
+		}
 
         let appId = utils.sanitizeString(process.env.INPUT_APPLICATION_ID);
         if(!appId) {
             reject(constants.ERROR_INVALID_APP_ID);
             return;
         }
-
+		
         executeCommand(`queue_analysis -a ${appId} ${args}`)
         .then((stdout) => {
             //Get the scan id from stdout and return it.

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ function getOS() {
 
 function sanitizeString(input) {
     if(input) {
-        input = input.replace('[^a-zA-Z0-9\\-\\._]', '');
+        input = input.replace('[^a-zA-Z0-9\\-\\._:\\/]', '');
     }
     return input;
 }


### PR DESCRIPTION
Added -c option to allow users to provide a comment for scans in queue_analysis command.