### PR TITLE
Resolved the issue by correctung the promise chain behaviour.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ saclientutil.downloadClient()
     }
     
     if(process.env.INPUT_WAIT_FOR_ANALYSIS !== 'true') {
-        return resolve();
+        return Promise.resolve();
     }
 
     core.info(constants.WAIT_FOR_ANALYSIS);
@@ -68,7 +68,7 @@ saclientutil.downloadClient()
 .then((timedOut) => {
     if(timedOut) {
         core.warning(constants.ANALYSIS_TIMEOUT);
-        return resolve();
+        return Promise.resolve();
     }
     core.info(constants.GETTING_RESULTS);
     return resultProcessor.processScanResults(sastScanId, scaScanId);


### PR DESCRIPTION
The code is executing inside a Promise chain (.then(...)). Earlier, it incorrectly attempted to call resolve(), which is only available inside a new Promise((resolve, reject) => { ... }) executor. Since there is no resolve in scope, it resulted in a ReferenceError.

Replacing it with return Promise.resolve(); preserves the original intent of completing the current asynchronous step successfully and continuing the promise chain without error. It also makes the asynchronous intent explicit to readers, whereas a bare return; relies on the implicit conversion of undefined to a resolved promise by the Promise implementation.